### PR TITLE
Use consistent image tags based on git tag and commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-VERSION=$(shell git rev-parse HEAD)
+VERSION=$(shell git describe --tags --match=v* --always --dirty)
 
 LOCAL_REPO=poseidon/dnsmasq
 IMAGE_REPO=quay.io/poseidon/dnsmasq


### PR DESCRIPTION
Use the standard image tag naming convention, `vRELEASE-NUM-SHA{8}`