### PR TITLE
dumb-init for proper zombie and signal handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/alpine:3.15.0
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
-RUN apk -U add dnsmasq curl
+RUN apk -U add dnsmasq curl dumb-init
 COPY tftpboot /var/lib/tftpboot
 EXPOSE 53 67 69
-ENTRYPOINT ["/usr/sbin/dnsmasq"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/sbin/dnsmasq"]


### PR DESCRIPTION
Without a proper init process, signal handling is mostly broken for running applications as well zombie processes may accumulate. 

[dumb-init](https://github.com/Yelp/dumb-init) is a minimal init script to take care of that. I think it is worth having it, for example to run dnsmasq with `--keep-in-foreground --user=root` instead of `-d`.